### PR TITLE
Fix: goreleaser creates the wrong homebrew cask path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,7 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
-    wrap_in_directory: true
+    wrap_in_directory: false
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
Since goreleaser wraps the built binary with a directory, the generated homebrew cask fails to symlink the binary correctly. This PR disables wrap_in_directory